### PR TITLE
update info for Netdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ HOOKDECK_CLI_TELEMETRY_OPTOUT=ANY_VALUE
 
 ### [Netdata](https://www.netdata.cloud)
 
-> Starting with v1.12, Netdata collects anonymous usage information by default and sends it to Google Analytics.
+> By default, Netdata collects anonymous usage information from the open-source monitoring agent using the open-source product analytics platform [PostHog](https://github.com/PostHog/posthog). We self-host our PostHog instance, which means your data is never sent or processed by any third parties outside of the Netdata infrastructure.
 
 - [Telemetry details](https://learn.netdata.cloud/docs/agent/anonymous-statistics)
 - [Privacy policy](https://learn.netdata.cloud/docs/agent/privacy-policy/)

--- a/README.md
+++ b/README.md
@@ -823,6 +823,20 @@ Use methods described below to opt-out of this telemetry channel.
 DO_NOT_TRACK=1
 ```
 
+##### 2. Create empty file
+
+Create an empty file in your Netdata configuration directory to opt out.
+
+###### Scope: 👤 User
+
+| OS      | Path                                                      |
+|---------|-----------------------------------------------------------|
+| Linux   | `/etc/netdata/.opt-out-from-anonymous-statistics`         |
+
+##### 3. Add option during installer script
+
+Pass the option `--disable-telemetry` to the installer script when installing or upgrading.
+
 ### [Netlify CLI](https://netlify.com)
 
 > By default, Netlify collects data on usage of Netlify CLI commands. We do this to improve the reliability and performance of Netlify CLI, and to help drive new features and improvements.


### PR DESCRIPTION
Hello - i work for Netdata on data and ML (so trying to make use of the telemetry data to help make the product better or catch issues earlier - so vested interest obviously :) ), 

We have, a while back, removed Google Analytics and Google Tag Manager from the agent dashboard and moved all telemetry over to a self hosted PostHog in our infra instead. So similar anon telemetry still being collected but just nothing going to Google with was one thing our users did not like, even those that did not quite mind idea of telemetry data but just hated idea of Google being part of it in any way. 

Anyway - i just wanted to make the small update here to reflect the latest updates in our docs at the same link you have here. 

Please let me know if anywhere else i should add to this PR to update or if this looks ok.

Cheers,
Andy

Please refer to contributing documentation for any questions: [CONTRIBUTING](/docs/CONTRIBUTING.md)

### Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] I've run `.\build.ps1` and all tests are green
